### PR TITLE
Fix #21: Improve support for Python 2.7.6

### DIFF
--- a/haxor_news/config.py
+++ b/haxor_news/config.py
@@ -161,7 +161,10 @@ class Config(object):
         parser = configparser.RawConfigParser()
         try:
             with open(config_file_path) as config_file:
-                parser.read_file(config_file)
+                try:
+                    parser.read_file(config_file)
+                except AttributeError:
+                    parser.readfp(config_file)
                 for config_func in config_funcs:
                     config_func(parser)
         except IOError:

--- a/haxor_news/lib/html2text/html2text.py
+++ b/haxor_news/lib/html2text/html2text.py
@@ -180,7 +180,10 @@ def list_numbering_start(attrs):
 
 class HTML2Text(HTMLParser.HTMLParser):
     def __init__(self, out=None, baseurl=''):
-        HTMLParser.HTMLParser.__init__(self, convert_charrefs=False)
+        try:
+            HTMLParser.HTMLParser.__init__(self, convert_charrefs=False)
+        except TypeError:
+            HTMLParser.HTMLParser.__init__(self)
 
         # Config options
         self.unicode_snob = UNICODE_SNOB


### PR DESCRIPTION
Calls not available on older versions of Python are wrapped in a try/catch block.  If the calls are not available, the older version of the call is made instead.
