### PR TITLE
Better handle requests exceptions

### DIFF
--- a/haxor_news/web_viewer.py
+++ b/haxor_news/web_viewer.py
@@ -103,7 +103,13 @@ class WebViewer(object):
         :rtype: str
         :return: The string representation of the formatted url contents.
         """
-        raw_response = requests.get(url)
+        try:
+            raw_response = requests.get(url)
+        except (requests.exceptions.SSLError,
+                requests.exceptions.ConnectionError) as e:
+            contents = 'Error: ' + str(e) + '\n'
+            contents += 'Try running hn view # with the --browser/-b flag\n'
+            return contents
         contents = self.html_to_text.handle(raw_response.text)
         contents = self.format_markdown(contents)
         return contents


### PR DESCRIPTION
requests.exceptions.SSLError and requests.exceptions.ConnectionError now result in a message to use the --browser/-b option to display the results in a browser.
