### PR TITLE
fix #9, exceprion 'InsecurePlatform' in 'import requests'

### DIFF
--- a/haxor_news/lib/haxor/haxor.py
+++ b/haxor_news/lib/haxor/haxor.py
@@ -32,13 +32,7 @@ from __future__ import unicode_literals
 import datetime
 import json
 import sys
-
 import requests
-try:
-    import requests.packages.urllib3
-    requests.packages.urllib3.disable_warnings()
-except:
-    pass
 
 from .settings import supported_api_versions
 

--- a/haxor_news/lib/haxor/haxor.py
+++ b/haxor_news/lib/haxor/haxor.py
@@ -34,6 +34,11 @@ import json
 import sys
 
 import requests
+try:
+    import requests.packages.urllib3
+    requests.packages.urllib3.disable_warnings()
+except:
+    pass
 
 from .settings import supported_api_versions
 

--- a/haxor_news/web_viewer.py
+++ b/haxor_news/web_viewer.py
@@ -21,11 +21,6 @@ from .compat import HTMLParser
 from .lib.html2text.html2text import HTML2Text
 import click
 import requests
-try:
-    import requests.packages.urllib3
-    requests.packages.urllib3.disable_warnings()
-except:
-    pass
 
 
 class WebViewer(object):

--- a/haxor_news/web_viewer.py
+++ b/haxor_news/web_viewer.py
@@ -21,6 +21,11 @@ from .compat import HTMLParser
 from .lib.html2text.html2text import HTML2Text
 import click
 import requests
+try:
+    import requests.packages.urllib3
+    requests.packages.urllib3.disable_warnings()
+except:
+    pass
 
 
 class WebViewer(object):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     extras_require={
         'testing': [
             'mock>=1.0.1',
-            'tox>=1.9.2'
+            'tox>=1.9.2',
+            'requests[security]',
         ],
     },
     entry_points={


### PR DESCRIPTION
When you launch on Linux, it displays a warning about the impossibility to create a SSL connection:
![screenshot - 18 04 2016 - 07 44 00](https://cloud.githubusercontent.com/assets/13240952/14594561/7399023c-0540-11e6-9bbd-a9e8bb7cd245.png)

This is corrected by setting the required libraries:
```Shell
$ sudo apt-get install python-dev libffi-dev libssl-dev
```

But we do not download the password :) Therefore, these warnings can be ignored and will:
![screenshot - 18 04 2016 - 08 38 18](https://cloud.githubusercontent.com/assets/13240952/14594614/f537bb1c-0540-11e6-973a-96c9484b3fe6.png)


