### PR TITLE
Added `exit` command to quit Haxor CLI

### DIFF
--- a/haxor_news/haxor.py
+++ b/haxor_news/haxor.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import os
 import platform
 import subprocess
+import sys
 
 import click
 from prompt_toolkit import AbortAction, Application, CommandLineInterface
@@ -203,4 +204,5 @@ class Haxor(object):
         click.echo('Syntax: hn <command> [params] [options]')
         while True:
             document = self.cli.run()
+            if (document.text == 'exit'): sys.exit()
             self.run_command(document)


### PR DESCRIPTION
In reference to issue #51.

This pull request contains code that allows us to exit the `haxor` terminal CLI without using the F10 key using the `exit` command itself like the shell prompt. 

Can be handy in situations where F10 is used for something else (example in GNOME Terminal F10 opens File Menu).