### PR TITLE
Add space between link and ellipsis

### DIFF
--- a/haxor_news/hacker_news.py
+++ b/haxor_news/hacker_news.py
@@ -556,7 +556,7 @@ class HackerNews(object):
                     sys.stderr.close()
                 self.config.save_cache()
         else:
-            click.secho('\nOpening ' + item.url + '...',
+            click.secho('\nOpening ' + item.url + ' ...',
                         fg=self.config.clr_general)
             if browser:
                 webbrowser.open(item.url)


### PR DESCRIPTION
The tiniest pull request ever 😄 Added a space after the link so that I can cmd-click it in my shell and it opens the page in the browser. Currently I have to delete the trailing dots in the browser nav bar.

Thanks!