### PR TITLE
Modify the arg_completions function

### DIFF
--- a/haxor_news/completer.py
+++ b/haxor_news/completer.py
@@ -148,10 +148,12 @@ class Completer(Completer):
         """
         if 'hn' not in words:
             return []
-        for subcommand, args_opts in ARGS_OPTS_LOOKUP.items():
-            if subcommand in words:
-                return [ARGS_OPTS_LOOKUP[subcommand]['args']]
-        return ['10']
+        input_subcommand = words[1]
+        if input_subcommand in ARGS_OPTS_LOOKUP:
+            return [ARGS_OPTS_LOOKUP[input_subcommand]['args']]
+        if input_subcommand in SUBCOMMANDS:
+            return ['10']
+        return []
 
     def get_completions(self, document, _):
         """Get completions for the current scope.


### PR DESCRIPTION
Fixed that arg is displayed even if the subcommand is wrong.

before:
 "hoge" is wrong subcommand. but, arg suggestion("10     limit: int (opt) limits the posts displayed") is displayed.
```bash
haxor> hn hoge
               10     limit: int (opt) limits the posts displayed
```

after:
"hoge" is wrong subcommand. so, suggestion is not displayed.
```bash
haxor> hn hoge
```

Please confirm!

