### PR TITLE
Fix _safe_split function

### DIFF
--- a/haxor_news/utils.py
+++ b/haxor_news/utils.py
@@ -178,4 +178,4 @@ class TextUtils(object):
             words = self._shlex_split(text)
             return words
         except:
-            return text
+            return []


### PR DESCRIPTION
Fixed return value of _safe_split function.

_safe_split function return value is list type, but If an exception occurs, str type is returned.
At that time, get_completions() -> completing_subcommand_option() -> return [](in https://github.com/donnemartin/haxor-news/blob/master/haxor_news/completer.py 184 line).
This is the same as to return [] in completer.py 172 line.
So, If an exception occurs, [] is returned in _safe_split, the behavior does not change!

Please confirm!

