### PR TITLE
Fix #167: Update latest monthly hiring post ids

### DIFF
--- a/haxor_news/settings.py
+++ b/haxor_news/settings.py
@@ -14,5 +14,5 @@
 # language governing permissions and limitations under the License.
 
 # Updated monthly, see HackerNewsCli.hiring docstring.
-who_is_hiring_post_id = 18589702
-freelancer_post_id = 18589703
+who_is_hiring_post_id = 19055166
+freelancer_post_id = 19055165


### PR DESCRIPTION
Update bot values with February 2019 posts.

Not sure where the value for "Ask HN: Who wants to be hired?" should be put?
 - the value is `19055164` for that