### PR TITLE
set maximum version of prompt-toolkit to be 2.0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'colorama>=0.3.3,<1.0.0',
         'requests>=2.4.3,<3.0.0',
         'pygments>=2.0.2,<3.0.0',
-        'prompt-toolkit>=1.0.0,<1.1.0',
+        'prompt-toolkit>=1.0.0,<2.0.10',
         'six>=1.9.0,<2.0.0',
     ],
     extras_require={


### PR DESCRIPTION
This should not break anything, but just to be safe could someone test this before possible merge.