### PR TITLE
docs: fix simple typo, uppor -> upper

### DIFF
--- a/haxor_news/hacker_news.py
+++ b/haxor_news/hacker_news.py
@@ -392,7 +392,7 @@ class HackerNews(object):
         """Create the tip about the view command.
 
         :type max_index: string
-        :param max_index: The index uppor bound, used with the
+        :param max_index: The index upper bound, used with the
             hn view [index] commend.
 
         :rtype: str


### PR DESCRIPTION
There is a small typo in haxor_news/hacker_news.py.

Should read `upper` rather than `uppor`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md